### PR TITLE
Rename Fx to Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@ _TODO: Add example_
 Let's start with the types and some basic intuitions about the pieces:
 
 ```typescript
-type Fx<R, A> = ...
+type Env<R, A> = ...
 
-function chain <RA, RB, A, B> (f: (a: A) => Fx<RB, B>, fx: Fx<RA, A>): Fx<RA & RB, B>
+function chain <RA, RB, A, B> (f: (a: A) => Env<RB, B>, e: Env<RA, A>): Env<RA & RB, B>
 
-function use <RA, RB, A> (rb: RB, fx: Fx<RA & RB, A>): Fx<RA, A>
+function use <RA, RB, A> (rb: RB, e: Env<RA & RB, A>): Env<RA, A>
 
-function runPure <A> (fx: Fx<{}, A>, k: (a: A) => void = () => {}): Cancel
+function runPure <A> (e: Env<{}, A>, k: (a: A) => void = () => {}): Cancel
 ```
 
-- `Fx` represents computations that must execute in an _environment_ which provides a set of resources `R`.
-- `chain` _aggregates_ resource requirements by combining two `Fx` computations to produce a third `Fx` computation.
+- `Env` represents computations that must execute in an _environment_ which provides a set of resources `R`.
+- `chain` _aggregates_ resource requirements by combining two `Env` computations to produce a third `Env` computation.
 - `use` _eliminates_ resources requirements on the environment by providing some or all of the resources.
 - `runPure` executes a computation whose resource requirements have been _fully satisfied_.
 
-**Note the intersections `RA & RB` in `chain` and `use`**.  They are a key part of what makes `Fx` useful.
+**Note the intersections `RA & RB` in `chain` and `use`**.  They are a key part of what makes `Env` useful.
 
 ### Environment
 
@@ -43,39 +43,39 @@ An environment is a set of resources.  The resources can be anything: app config
 
 _TODO: Add example_
 
-### Fx at a glance
+### Env at a glance
 
-We'll go into more depth on the `Fx` type later.  For now, let's keep it simple: `Fx` represents a computation that will produce an `A` only if executed in an environment that provides a set of resources, `R`.
+We'll go into more depth on the `Env` type later.  For now, let's keep it simple: `Env` represents a computation that will produce an `A` only if executed in an environment that provides a set of resources, `R`.
 
-_For the next few sections_, think of `Fx` as being like a function:
+_For the next few sections_, think of `Env` as being like a function:
 
 ```typescript
-type Fx<R, A> = (r: R) => A
+type Env<R, A> = (r: R) => A
 ```
 
 ### Executing a computation
 
-If `Fx` is like a function, clearly we need to provide an `R` to execute it.  At first glance, then, `runPure`'s type may seem confusing.
+If `Env` is like a function, clearly we need to provide an `R` to execute it.  At first glance, then, `runPure`'s type may seem confusing.
 
 ```typescript
-function runPure <A> (fx: Fx<{}, A>, ...): ...
+function runPure <A> (e: Env<{}, A>, ...): ...
 ```
 
-It can only execute computations that require no resources. We need a way to reduce the requirements of an `Fx` to the empty set so that we can execute it with `runPure`.
+It can only execute computations that require no resources. We need a way to reduce the requirements of an `Env` to the empty set so that we can execute it with `runPure`.
 
 ### Satisfying requirements
 
 Let's look at the type of `use`:
 
 ```typescript
-function use <RA, RB, A> (rb: RB, fx: Fx<RA & RB, A>): Fx<RA, A>
+function use <RA, RB, A> (rb: RB, e: Env<RA & RB, A>): Env<RA, A>
 ```
 
-Notice how the _input_, `fx`, requires `RA & RB`, and the _output_ `Fx` requires only `RA`.  By providing an `RB`, `use` satisfies some or all of `fx`'s requirements.  To put it another way, by providing `RB`, `use` subtracts `RB` from `fx`'s requirements, leaving only `RA`.
+Notice how the _input_, `e`, requires `RA & RB`, and the _output_ `Env` requires only `RA`.  By providing an `RB`, `use` satisfies some or all of `e`'s requirements.  To put it another way, by providing `RB`, `use` subtracts `RB` from `e`'s requirements, leaving only `RA`.
 
-When `RB` contains a subset of the resources required by `fx`, `use` returns an `Fx` with a smaller set of requirements.
+When `RB` contains a subset of the resources required by `e`, `use` returns an `Env` with a smaller set of requirements.
 
-Crucially, when `RB` contains _all_ the resources of `RA` (i.e. `RB` is the same as, or a width subtype of `RA`), `use` returns an `Fx` whose requirements have been fully satisfied, and can be executed with `runPure`.
+Crucially, when `RB` contains _all_ the resources of `RA` (i.e. `RB` is the same as, or a width subtype of `RA`), `use` returns an `Env` whose requirements have been fully satisfied, and can be executed with `runPure`.
 
 ### Building computations
 
@@ -87,7 +87,7 @@ type UserService = {
   lookupUserByUsername: (username: string) => Promise<User>
 }
 // Getting a User requires UserService
-function getUserByUsername(username: string): Fx<UserService, User> {
+function getUserByUsername(username: string): Env<UserService, User> {
   // ...
 }
 
@@ -96,7 +96,7 @@ type EmailService = {
   sendMessage: (message: EmailMessage) => Promise<EmailSendStatus>
 }
 // Sending email requires EmailService
-function sendEmail(to: Email, subject: string, body: string): Fx<EmailService, EmailSendStatus> {
+function sendEmail(to: Email, subject: string, body: string): Env<EmailService, EmailSendStatus> {
   // ...
 }
 ```
@@ -104,15 +104,15 @@ function sendEmail(to: Email, subject: string, body: string): Fx<EmailService, E
 It may seem that we need to call each, then call `use` twice to satisfy the requirements of each, and then call `runPure` on each.  Instead, we can use `chain`:
 
 ```typescript
-function chain <RA, RB, A, B> (f: (a: A) => Fx<RB, B>, fx: Fx<RA, A>): Fx<RA & RB, B>
+function chain <RA, RB, A, B> (f: (a: A) => Env<RB, B>, e: Env<RA, A>): Env<RA & RB, B>
 ```
 
-`chain` allows us to write a new computation that gets a User by username and then sends them an email. Note the intersection `RA & RB` in the _output_ `Fx`.
+`chain` allows us to write a new computation that gets a User by username and then sends them an email. Note the intersection `RA & RB` in the _output_ `Env`.
 
-In contrast to `use`, which has an intersection in its _input_ `Fx` and _eliminates_ requirements, `chain` has an intersection in its _output_ and _aggregates_ requirements.
+In contrast to `use`, which has an intersection in its _input_ `Env` and _eliminates_ requirements, `chain` has an intersection in its _output_ and _aggregates_ requirements.
 
 ```typescript
-function sendWelcomeEmailToUsername (username: string): Fx<UserService & EmailService, EmailSendStatus> {
+function sendWelcomeEmailToUsername (username: string): Env<UserService & EmailService, EmailSendStatus> {
   return chain(
     getUserByName(username),
     user => sendEmail(user.email, 'Welcome!', `Hi ${user.displayName}, welcome to the world of composable computations!`
@@ -129,41 +129,41 @@ const userService: UserService = //...
 const emailService: EmailService = //...
 
 // Create a computation that will lookup user 'brian' and send a welcome email
-const fx: Fx<UserService & EmailService, EmailSendStatus> = sendWelcomeEmailToUsername('brian')
+const computation: Env<UserService & EmailService, EmailSendStatus> = sendWelcomeEmailToUsername('brian')
 
 // Provide all the required resources
-const pureFx: Fx<{}, EmailSendStatus> = use({ ...userService, ...emailService }, fx)
+const pureComputation: Env<{}, EmailSendStatus> = use({ ...userService, ...emailService }, computation)
 
 // Go! Lookup user 'brian' and send a welcome email
-runPure(pureFx)
+runPure(pureComputation)
 ```
 
-### Fx in depth
+### Env in depth
 
-There's a lot going on in the `Fx` type, so let's step through it from left to right.
+There's a lot going on in the `Env` type, so let's step through it from left to right.
 
 ```typescript
-type Fx<R, A> ...
+type Env<R, A> ...
 ```
 
-`Fx` represents a computation that will produce an `A` only if executed in an environment that satisfies its set of requirements, `R`.  What does it mean to "satisfy a set of requirements"?
+`Env` represents a computation that will produce an `A` only if executed in an environment that satisfies its set of requirements, `R`.  What does it mean to "satisfy a set of requirements"?
 
 ```typescript
-type Fx<R, A> = (r: R, ...) => ...
+type Env<R, A> = (r: R, ...) => ...
 ```
 
-`Fx` is a function type.  It must be called with an `R` in order to produce an `A`.  Thus, you "satisfy" its set of requirements `R` by calling it with an `R`.  If you're familiar with the Reader type (such as [Haskell's Reader](http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Reader.html)), you may recognize this as being similar to the [ReaderT pattern](https://www.fpcomplete.com/blog/2017/06/readert-design-pattern).
+`Env` is a function type.  It must be called with an `R` in order to produce an `A`.  Thus, you "satisfy" its set of requirements `R` by calling it with an `R`.  If you're familiar with the Reader type (such as [Haskell's Reader](http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Reader.html)), you may recognize this as being similar to the [ReaderT pattern](https://www.fpcomplete.com/blog/2017/06/readert-design-pattern).
 
 Where does the `A` go?
 
 ```typescript
-type Fx<R, A> = (r: R, k: (a: A) => void) => ...
+type Env<R, A> = (r: R, k: (a: A) => void) => ...
 ```
 
-The `k` parameter is a _continuation_.  By using a continuation instead of returning an `A`, `Fx` supports both synchronous and asynchronous computations.  Finally, let's look at the last piece, the return type.
+The `k` parameter is a _continuation_.  By using a continuation instead of returning an `A`, `Env` supports both synchronous and asynchronous computations.  Finally, let's look at the last piece, the return type.
 
 ```typescript
-type Fx<R, A> = (r: R, k: (a: A) => void) => Cancel
+type Env<R, A> = (r: R, k: (a: A) => void) => Cancel
 ```
 
-`Fx` returns a `Cancel`, which allows the caller to abort an in-flight asynchronous computation.
+`Env` returns a `Cancel`, which allows the caller to abort an in-flight asynchronous computation.

--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,8 +1,8 @@
-import { Cancel, chain, Fx, map, runPure, uncancelable, use } from '../src'
+import { Cancel, chain, Env, map, runPure, uncancelable, use } from '../src'
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-export const forever = <R, A>(fx: Fx<R, A>): Fx<R, never> =>
+export const forever = <R, A>(fx: Env<R, A>): Env<R, never> =>
   chain(() => forever(fx), fx)
 
 // Print effect and constructor
@@ -10,7 +10,7 @@ type Print = {
   print(s: string, k: (r: void) => void): Cancel
 }
 
-const print = (s: string): Fx<Print, void> =>
+const print = (s: string): Env<Print, void> =>
   ({ print }, k) => print(s, k)
 
 // Read effect and constructor
@@ -18,7 +18,7 @@ type Read = {
   read(k: (r: string) => void): Cancel
 }
 
-const read: Fx<Read, string> =
+const read: Env<Read, string> =
   ({ read }, k) => read(k)
 
 // Helper to append newlines
@@ -26,7 +26,7 @@ const addEol = (s: string): string => `${s}${EOL}`
 
 // Effectful computation that prints a prompt, reads
 // user input and prints it.
-const echo: Fx<Print & Read, void> =
+const echo: Env<Print & Read, void> =
   chain(() => chain(print, map(addEol, read)), print('> '))
 
 // To run echo, we need to provide usingrs for the

--- a/examples/echo-console.ts
+++ b/examples/echo-console.ts
@@ -1,20 +1,16 @@
-import { Cancel, chain, Env, map, runPure, uncancelable, use } from '../src'
+import { Cancel, chain, Env, forever, map, runPure, use, withEnv } from '../src'
 import { EOL } from 'os'
 import { createInterface } from 'readline'
 
-// Helper to loop a computation forever
-const forever = <R, A>(e: Env<R, A>): Env<R, never> =>
-  chain(() => forever(e), e)
-
-// Print effect and constructor
+// Print capability
 type Print = {
-  print (s: string, k: (r: void) => void): Cancel
+  print (s: string): void
 }
 
 const print = (s: string): Env<Print, void> =>
-  ({ print }, k) => print(s, k)
+  withEnv(({ print }) => print(s))
 
-// Read effect and constructor
+// Read capability
 type Read = {
   read (k: (r: string) => void): Cancel
 }
@@ -23,7 +19,7 @@ const read: Env<Read, string> =
   ({ read }, k) => read(k)
 
 // Helper to append newlines
-const addEol = (s: string): string => `${s}${EOL}`
+const addEol = (s: string): string => s + EOL
 
 // Effectful computation that prints a prompt, reads
 // user input and prints it.
@@ -31,23 +27,21 @@ const echo: Env<Print & Read, void> =
   chain(() => chain(print, map(addEol, read)), print('> '))
 
 // To run echo, we need to provide implementations of
-// Read and Print
+// Print and Read
 
 // We'll use node's readline to implement Read
 const readline = createInterface({
-  input: process.stdin,
-  output: process.stdout
+  input: process.stdin
 })
 
 // Concrete Print and Read implementations
-const resources: Print & Read = {
-  print: (s, k): Cancel =>
-    uncancelable(k(void process.stdout.write(s))),
+const capabilities: Print & Read = {
+  print: s => void process.stdout.write(s),
   read: k => {
     readline.once('line', k)
     return () => readline.removeListener('line', k)
   }
 }
 
-// Loop echo forever using the effect usingrs
-runPure(use(resources, forever(echo)))
+// Loop echo forever using the Print and Read capabilities
+runPure(use(capabilities, forever(echo)))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,21 +3,21 @@ export type Cancel = () => void
 export const uncancelable = <A> (_: A): Cancel =>
   () => {}
 
-export type Fx<R, A> = (r: R, k: (a: A) => void) => Cancel
+export type Env<R, A> = (r: R, k: (a: A) => void) => Cancel
 
-export const use = <RA, RB, A>(rb: RB, e: Fx<RA & RB, A>): Fx<RA, A> =>
+export const use = <RA, RB, A>(rb: RB, e: Env<RA & RB, A>): Env<RA, A> =>
   (ra, k) => e({ ...rb, ...ra } as RA & RB, k)
 
-export const runPure = <A>(e: Fx<{}, A>, k: (a: A) => void = () => {}): Cancel =>
+export const runPure = <A>(e: Env<{}, A>, k: (a: A) => void = () => {}): Cancel =>
   e({}, k)
 
-export const pure = <A>(a: A): Fx<{}, A> =>
+export const pure = <A>(a: A): Env<{}, A> =>
   (_, k) => uncancelable(k(a))
 
-export const map = <R, A, B> (f: (a: A) => B, e: Fx<R, A>): Fx<R, B> =>
+export const map = <R, A, B> (f: (a: A) => B, e: Env<R, A>): Env<R, B> =>
   (r, k) => e(r, a => k(f(a)))
 
-export const chain = <RA, RB, A, B>(f: (a: A) => Fx<RB, B>, e: Fx<RA, A>): Fx<RA & RB, B> =>
+export const chain = <RA, RB, A, B>(f: (a: A) => Env<RB, B>, e: Env<RA, A>): Env<RA & RB, B> =>
   (rab, k) => {
     let cancel = e(rab, a => {
       cancel = f(a)(rab, k)


### PR DESCRIPTION
This is not about effects in the algebraic or really any other sense.  It's about requirements. I wrote this in slack the other day:

> it’s basically “just” Reader + type intersection and subtraction
> and sometimes Reader is referred to as Env

I also think "computations in an environment" is a fairly strong mental model.  I guess it could be named `Computation` or `Comp` as well.  For now, I prefer `Env`, but def open to other options.